### PR TITLE
maintain scroll position when returning to list

### DIFF
--- a/src/components/posts/PostsList.tsx
+++ b/src/components/posts/PostsList.tsx
@@ -38,6 +38,35 @@ function PostsList({ posts, fetchNextPage, hasNextPage, loading, isInitialLoadin
         };
     }, [hasNextPage, fetchNextPage]);
 
+    useEffect(() => {
+        const restore = () => {
+            try {
+                const stored = sessionStorage.getItem('postsListScrollY');
+                if (!stored) return;
+                const y = parseInt(stored, 10);
+                if (Number.isNaN(y)) return;
+
+                window.scrollTo(0, y);
+
+                const rafId = requestAnimationFrame(() => window.scrollTo(0, y));
+                const timeoutId = window.setTimeout(() => window.scrollTo(0, y), 50);
+
+                sessionStorage.removeItem('postsListScrollY');
+
+                return () => {
+                    cancelAnimationFrame(rafId);
+                    clearTimeout(timeoutId);
+                };
+            } catch (_) {
+            }
+        };
+
+        const cleanup = restore();
+        return () => {
+            if (typeof cleanup === 'function') cleanup();
+        };
+    }, [posts.length, isInitialLoading]);
+
     if (isInitialLoading) {
         return <Loader />;
     }

--- a/src/components/posts/SinglePost.tsx
+++ b/src/components/posts/SinglePost.tsx
@@ -48,6 +48,10 @@ function SinglePost({ id, messageTo, message, timestamp, likes, shares, messageS
 
         if (disabled || isInteractionDisabled) return;
 
+        try {
+            sessionStorage.setItem('postsListScrollY', String(window.scrollY));
+        } catch (_) {
+        }
         navigate(`/post/${id}`, { state: { fromList: true } })
     };
 


### PR DESCRIPTION
Save `window.scrollY` to `sessionStorage` before navigating to a single post (src/components/posts/SinglePost.tsx)

Restore scroll on `PostsList` mount after content renders with immediate, `requestAnimationFrame`, and 50ms timeout retries; then clear the stored value (src/components/posts/PostsList.tsx)

Improves UX by returning users to their previous position after viewing a post